### PR TITLE
Visitor can see a specific rental space

### DIFF
--- a/cypress/fixtures/listing_show.json
+++ b/cypress/fixtures/listing_show.json
@@ -1,0 +1,15 @@
+{
+  "listings": [
+
+    {
+      "id": 2,
+      "lead": "Great parking spot in central of Stockholm.",
+      "scene": "indoor",
+      "category": "Parking spot",
+      "image": "https://i.redd.it/w3kr4m2fi3111.png",
+      "description": "Heated garage in the middle of Stockholm that fits one big SUV.",
+      "adress": "Sibyllegatan 18, 11442 Stockholm",
+      "price": 200
+    }
+  ]
+}

--- a/cypress/fixtures/listing_show.json
+++ b/cypress/fixtures/listing_show.json
@@ -8,7 +8,7 @@
       "category": "Parking spot",
       "image": "https://i.redd.it/w3kr4m2fi3111.png",
       "description": "Heated garage in the middle of Stockholm that fits one big SUV.",
-      "adress": "Sibyllegatan 18, 11442 Stockholm",
+      "address": "Sibyllegatan 18, 11442 Stockholm",
       "price": 200
     }
   ]

--- a/cypress/integration/visitorCanSeeSpecificListing.featur.js
+++ b/cypress/integration/visitorCanSeeSpecificListing.featur.js
@@ -1,0 +1,32 @@
+describe("Vistors can see specific listing", () => {
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/listings",
+      response: "fixture:listing_index.json",
+    });
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/listings/2",
+      response: "fixture:listing_show.json",
+    });
+
+    cy.visit("/");
+    cy.get('[data-cy=listing-2]').click()
+  });
+  it("displays the content of the article", () => {
+    cy.get('[data-cy=listing-2]').within(() => {
+      cy.get('[data-cy=lead]').should("contain", "Great parking spot in central of Stockholm.");
+      cy.get('[data-cy=scene]').should("contain", "indoor");
+      cy.get('[data-cy=price]').should("contain", 200)
+      cy.get('[data-cy=adress]').should("contain", "Sibyllegatan 18, 11442 Stockholm")
+      cy.get('[data-cy=description]').should(
+        "contain",
+        "Heated garage in the middle of Stockholm that fits one big SUV."
+      );
+    });
+    cy.get("#listing-1").should("not.exist");
+    cy.get("#listing-3").should("not.exist");
+  });
+});

--- a/cypress/integration/visitorCanSeeSpecificListing.feature.js
+++ b/cypress/integration/visitorCanSeeSpecificListing.feature.js
@@ -22,7 +22,7 @@ describe("Vistors can see specific listing", () => {
       cy.get('[data-cy=lead]').should("contain", "Great parking spot in central of Stockholm.");
       cy.get('[data-cy=scene]').should("contain", "indoor");
       cy.get('[data-cy=price]').should("contain", "200")
-      cy.get('[data-cy=adress]').should("contain", "Sibyllegatan 18, 11442 Stockholm")
+      cy.get('[data-cy=address]').should("contain", "Sibyllegatan 18, 11442 Stockholm")
       cy.get('[data-cy=description]').should(
         "contain",
         "Heated garage in the middle of Stockholm that fits one big SUV."

--- a/cypress/integration/visitorCanSeeSpecificListing.feature.js
+++ b/cypress/integration/visitorCanSeeSpecificListing.feature.js
@@ -4,7 +4,7 @@ describe("Vistors can see specific listing", () => {
     cy.route({
       method: "GET",
       url: "http://localhost:3000/api/v1/listings",
-      response: "fixture:listing_index.json",
+      response: "fixture:listings_index.json",
     });
     cy.route({
       method: "GET",
@@ -12,14 +12,16 @@ describe("Vistors can see specific listing", () => {
       response: "fixture:listing_show.json",
     });
 
-    cy.visit("/");
-    cy.get('[data-cy=listing-2]').click()
+    cy.visit("/rent-space");
+    cy.get('[data-cy=listing-2]').within(() => {
+      cy.get('[data-cy=button]').click()
+    });
   });
-  it("displays the content of the article", () => {
+  it("displays the content of the listing", () => {
     cy.get('[data-cy=listing-2]').within(() => {
       cy.get('[data-cy=lead]').should("contain", "Great parking spot in central of Stockholm.");
       cy.get('[data-cy=scene]').should("contain", "indoor");
-      cy.get('[data-cy=price]').should("contain", 200)
+      cy.get('[data-cy=price]').should("contain", "200")
       cy.get('[data-cy=adress]').should("contain", "Sibyllegatan 18, 11442 Stockholm")
       cy.get('[data-cy=description]').should(
         "contain",

--- a/public/index.html
+++ b/public/index.html
@@ -13,8 +13,6 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css"
     />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <title>Bidspace</title>
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ const App = (props) => {
         <Route exact path="/"> <LandingPage /> </Route>
         <Route exact path="/rent-space"> <ListingPage /> </Route>
         <Route exact path="/rentout-space"> <LandlordPage /> </Route>
-        <Route exact path="/listing/:id"> <SingleListing /> </Route>
+        <Route exact path="/listing/:id" component={SingleListing}></Route>
       </Switch>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import LandingPage from "./components/LandingPage";
 import ListingPage from "./components/ListingPage"
 import LandlordPage from "./components/LandlordPage"
+import SingleListing from "./components/SingleListing"
 
 const App = () => {
   return (
@@ -12,6 +13,7 @@ const App = () => {
         <Route exact path="/"> <LandingPage /> </Route>
         <Route exact path="/rent-space"> <ListingPage /> </Route>
         <Route exact path="/rentout-space"> <LandlordPage /> </Route>
+        <Route exact path="/single-listing"> <SingleListing /> </Route>
       </Switch>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,14 @@ import ListingPage from "./components/ListingPage"
 import LandlordPage from "./components/LandlordPage"
 import SingleListing from "./components/SingleListing"
 
-const App = () => {
+const App = (props) => {
   return (
     <div>
       <Switch>
         <Route exact path="/"> <LandingPage /> </Route>
         <Route exact path="/rent-space"> <ListingPage /> </Route>
         <Route exact path="/rentout-space"> <LandlordPage /> </Route>
-        <Route exact path="/single-listing"> <SingleListing /> </Route>
+        <Route exact path="/listing/:id"> <SingleListing /> </Route>
       </Switch>
     </div>
   );

--- a/src/components/ListingPage.jsx
+++ b/src/components/ListingPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
-import { Grid, Item, Label, Button } from "semantic-ui-react";
-import {Link } from "react-router-dom";
+import { Grid, Item, Label, Button, Icon } from "semantic-ui-react";
+import { Link } from "react-router-dom";
 
 const ListingPage = () => {
   const [listings, setListings] = useState([]);
@@ -23,9 +23,11 @@ const ListingPage = () => {
           <Item.Meta id="category">{listing.category}</Item.Meta>
           <Item.Extra>
             <Label data-cy="scene">{listing.scene}</Label>
-            <Link to={`listing/${listing.id}`}><Button data-cy="button" >
-               Check me out
-            </Button>
+            <Link to={`listing/${listing.id}`}>
+              <Button data-cy="button" primary floated="right">
+                Check me out
+                <Icon name="right chevron" />
+              </Button>
             </Link>
           </Item.Extra>
         </Item.Content>

--- a/src/components/ListingPage.jsx
+++ b/src/components/ListingPage.jsx
@@ -23,7 +23,7 @@ const ListingPage = () => {
           <Item.Meta id="category">{listing.category}</Item.Meta>
           <Item.Extra>
             <Label data-cy="scene">{listing.scene}</Label>
-            <Link to="/single-listing"><Button data-cy="button" >
+            <Link to={`listing/${listing.id}`}><Button data-cy="button" >
                Check me out
             </Button>
             </Link>

--- a/src/components/ListingPage.jsx
+++ b/src/components/ListingPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
-import { Grid, Item, Label } from "semantic-ui-react";
+import { Grid, Item, Label, Button } from "semantic-ui-react";
+import {Link } from "react-router-dom";
 
 const ListingPage = () => {
   const [listings, setListings] = useState([]);
@@ -22,6 +23,10 @@ const ListingPage = () => {
           <Item.Meta id="category">{listing.category}</Item.Meta>
           <Item.Extra>
             <Label data-cy="scene">{listing.scene}</Label>
+            <Link to="/single-listing"><Button data-cy="button" >
+               Check me out
+            </Button>
+            </Link>
           </Item.Extra>
         </Item.Content>
       </Item>

--- a/src/components/SingleListing.jsx
+++ b/src/components/SingleListing.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const SingleListing = () => {
+  return (
+    <div>
+      <h1>this is the single listing</h1>
+    </div>
+  )
+}
+
+export default SingleListing;

--- a/src/components/SingleListing.jsx
+++ b/src/components/SingleListing.jsx
@@ -1,11 +1,31 @@
-import React from 'react'
+import React, { useEffect, useState } from "react";
+import axios from "axios"
 
-const SingleListing = () => {
+const SingleListing = (props) => {
+  const listingId = props.match.params.id;
+  const setSingleListing = useState(null)
+
+  useEffect(() => {
+    debugger
+    getSingleListing();
+  }, []);
+
+  const getSingleListing = async () => {
+    debugger
+    let id = listingId
+    let response = await axios.get(`/listing/${id}`);
+    setSingleListing(response.data.listing);
+
+  };
+
+  let content={getSingleListing} 
+
   return (
     <div>
       <h1>this is the single listing</h1>
+      {content}
     </div>
-  )
-}
+  );
+};
 
 export default SingleListing;

--- a/src/components/SingleListing.jsx
+++ b/src/components/SingleListing.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { Item, Label } from "semantic-ui-react";
 
 const SingleListing = (props) => {
   const listingId = props.match.params.id;
-  const [singleListing, setSingleListing] = useState(null);
+  const [singleListing, setSingleListing] = useState([]);
 
   useEffect(() => {
-    debugger;
     getSingleListing();
   }, []);
 
@@ -17,17 +17,28 @@ const SingleListing = (props) => {
     setSingleListing(response.data.listings);
   };
 
-  let listingContent = (
-    <div
-    listing={singleListing}
-    >
-    </div>
-  );
+  let listingContent = singleListing.map((listing) => (
+    <Item.Group divided>
+      <Item data-cy={`listing-${listing.id}`} data-id={listing.id}>
+        <Item.Content>
+          <Item.Header data-cy="lead">{listing.lead}</Item.Header>
+          <Item.Meta data-cy="address">{listing.address}</Item.Meta>
+          <Item.Description data-cy="description">{listing.description}</Item.Description>
+          <Item.Extra>
+            <Label data-cy="scene">{listing.scene}</Label>
+            <Label data-cy="category">{listing.category}</Label>
+            <Label data-cy="price">{listing.price}</Label>
+          </Item.Extra>
+        </Item.Content>
+      </Item>
+    </Item.Group>
+  ));
+
+  console.log(singleListing);
 
   return (
     <>
       <div>
-        <h1>this is the single listing</h1>
         {listingContent}
       </div>
     </>

--- a/src/components/SingleListing.jsx
+++ b/src/components/SingleListing.jsx
@@ -11,7 +11,6 @@ const SingleListing = (props) => {
   }, []);
 
   const getSingleListing = async () => {
-    debugger;
     let id = listingId;
     let response = await axios.get(`/listings/${id}`);
     setSingleListing(response.data.listings);
@@ -34,7 +33,6 @@ const SingleListing = (props) => {
     </Item.Group>
   ));
 
-  console.log(singleListing);
 
   return (
     <>

--- a/src/components/SingleListing.jsx
+++ b/src/components/SingleListing.jsx
@@ -1,30 +1,36 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios"
+import axios from "axios";
 
 const SingleListing = (props) => {
   const listingId = props.match.params.id;
-  const setSingleListing = useState(null)
+  const [singleListing, setSingleListing] = useState(null);
 
   useEffect(() => {
-    debugger
+    debugger;
     getSingleListing();
   }, []);
 
   const getSingleListing = async () => {
-    debugger
-    let id = listingId
-    let response = await axios.get(`/listing/${id}`);
-    setSingleListing(response.data.listing);
-
+    debugger;
+    let id = listingId;
+    let response = await axios.get(`/listings/${id}`);
+    setSingleListing(response.data.listings);
   };
 
-  let content={getSingleListing} 
+  let listingContent = (
+    <div
+    listing={singleListing}
+    >
+    </div>
+  );
 
   return (
-    <div>
-      <h1>this is the single listing</h1>
-      {content}
-    </div>
+    <>
+      <div>
+        <h1>this is the single listing</h1>
+        {listingContent}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## https://www.pivotaltracker.com/story/show/174549413
### User Story
```
As a Visitor
In order to know about the details of a rental space
I would like to be able to click on a specific rental space and see the details
```
## Changes proposed in this pull request:
* ability to see specific listings.
## What I have learned working on this feature:
*  manipulating routes using id's
## Screenshots (Client)
![Skärmavbild 2020-09-02 kl  21 11 48](https://user-images.githubusercontent.com/65163161/92026248-05044d00-ed61-11ea-8c06-130e8693a0b8.png)
